### PR TITLE
doc(registering): Remove reference to platform domain

### DIFF
--- a/src/using-deis/registering-a-user.md
+++ b/src/using-deis/registering-a-user.md
@@ -8,9 +8,6 @@ To use Deis, you must first register a user on the [Controller][].
 Use `deis register` with the [Controller][] URL (supplied by your Deis administrator)
 to create a new account.  You will be logged in automatically.
 
-The domain you use here should match the platform domain you selected when configuring the [Router][].
-Note that you always use `deis.<domain>` to communicate with the controller.
-
     $ deis register http://deis.example.com
     username: myuser
     password:


### PR DESCRIPTION
Although it's still _probably_ a good idea to define a default domain on the router, that step is no longer strictly necessary, so the comment on this page about "The domain you use here should match the platform domain you selected when configuring the Router" is confusing and misleading.  Deleting it.