### PR TITLE
doc(registering): Make minor fixes to registering doc

### DIFF
--- a/src/using-deis/registering-a-user.md
+++ b/src/using-deis/registering-a-user.md
@@ -6,7 +6,8 @@ To use Deis, you must first register a user on the [Controller][].
 ## Register with a Controller
 
 Use `deis register` with the [Controller][] URL (supplied by your Deis administrator)
-to create a new account.  You will be logged in automatically.
+to create a new account.  When you have completed the registration process, you will be logged in
+automatically.
 
 The domain you use here should match the platform domain you selected when configuring the [Router][].
 Note that you always use `deis.<domain>` to communicate with the controller.
@@ -57,9 +58,6 @@ If you already have an account, use `deis login` to authenticate against the Dei
     username: deis
     password:
     Logged in as deis
-
-!!! note
-    For Vagrant clusters: `deis login http://deis.local3.deisapp.com`
 
 !!! note
     Deis session information is stored in your user's ~/.deis directory.


### PR DESCRIPTION
This bundles two minor fixes.  The first improves the clarity of the statement "you will be logged in automatically," which gave me just a minor head scratching moment when I read it.

The second removes the reference to use of the `http://deis.local3.deisapp.com` controller URL when using Vagrant.  That is a vestige of v1.  In DNS, `deis.local3.deisapp.com` round-robins through three specific private IPs where we used to run the VMs comprising a dev cluster.  Now that we defer k8s provisioning on Vagrant to whatever scripts k8s includes for that purpose, we cannot make any guarantee that the VM(s) use any specific IPs.