### PR TITLE
doc(deploying): Fix login instructions

### DIFF
--- a/src/using-deis/deploying-an-application.md
+++ b/src/using-deis/deploying-an-application.md
@@ -15,17 +15,15 @@ Fortunately, most modern applications feature a stateless application tier that 
 ## Login to the Controller
 
 !!! important
-	if you haven't yet, now is a good time to [install the client](installing-the-client.md).
+	if you haven't yet, now is a good time to [install the client](installing-the-client.md) and [register](registering-a-user.md).
 
-Before deploying an application, users must first authenticate against the Deis [Controller][].
+Before deploying an application, users must first authenticate against the Deis [Controller][]
+using the URL supplied by their Deis administrator.
 
     $ deis login http://deis.example.com
     username: deis
     password:
     Logged in as deis
-
-!!! note
-    For Vagrant clusters: `deis login http://deis.local3.deisapp.com`
 
 
 ## Select a Build Process


### PR DESCRIPTION
Similar to #18...

This bundles three minor fixes. The first reference registration instructions-- we can't be telling unregistered users to login.

The second clarifies that the "Deis administrator" is the source of the controller URL.

The third removes the reference to use of the http://deis.local3.deisapp.com controller URL when using Vagrant. That is a vestige of v1. In DNS, deis.local3.deisapp.com round-robins through three specific private IPs where we used to run the VMs comprising a dev cluster. Now that we defer k8s provisioning on Vagrant to whatever scripts k8s includes for that purpose, we cannot make any guarantee that the VM(s) use any specific IPs.