### PR TITLE
doc(deploying): Use example-go and update builder output

### DIFF
--- a/src/using-deis/using-buildpacks.md
+++ b/src/using-deis/using-buildpacks.md
@@ -7,8 +7,8 @@ Deis supports deploying applications via [Heroku Buildpacks][]. Buildpacks are u
 
 If you do not have an existing application, you can clone an example application that demonstrates the Heroku Buildpack workflow.
 
-    $ git clone https://github.com/deis/example-ruby-sinatra.git
-    $ cd example-ruby-sinatra
+    $ git clone https://github.com/deis/example-go.git
+    $ cd example-go
 
 
 ## Create an Application
@@ -16,7 +16,7 @@ If you do not have an existing application, you can clone an example application
 Use `deis create` to create an application on the [controller][].
 
     $ deis create
-    Creating application... done, created unisex-huntress
+    Creating application... done, created skiing-keypunch
     Git remote deis added
 
 
@@ -25,69 +25,39 @@ Use `deis create` to create an application on the [controller][].
 Use `git push deis master` to deploy your application.
 
     $ git push deis master
-    Counting objects: 95, done.
+    Counting objects: 75, done.
     Delta compression using up to 8 threads.
-    Compressing objects: 100% (52/52), done.
-    Writing objects: 100% (95/95), 20.24 KiB | 0 bytes/s, done.
-    Total 95 (delta 41), reused 85 (delta 37)
-    -----> Ruby app detected
-    -----> Compiling Ruby/Rack
-    -----> Using Ruby version: ruby-1.9.3
-    -----> Installing dependencies using 1.5.2
-           Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
-           Fetching gem metadata from http://rubygems.org/..........
-           Fetching additional metadata from http://rubygems.org/..
-           Using bundler (1.5.2)
-           Installing tilt (1.3.6)
-           Installing rack (1.5.2)
-           Installing rack-protection (1.5.0)
-           Installing sinatra (1.4.2)
-           Your bundle is complete!
-           Gems in the groups development and test were not installed.
-           It was installed into ./vendor/bundle
-           Bundle completed (8.81s)
-           Cleaning up the bundler cache.
+    Compressing objects: 100% (48/48), done.
+    Writing objects: 100% (75/75), 18.28 KiB | 0 bytes/s, done.
+    Total 75 (delta 30), reused 58 (delta 22)
+    Starting build... but first, coffee!
+    -----> Go app detected
+    -----> Checking Godeps/Godeps.json file.
+    -----> Installing go1.4.2... done
+    -----> Running: godep go install -tags heroku ./...
     -----> Discovering process types
            Procfile declares types -> web
-           Default process types for Ruby -> rake, console, web
-    -----> Compiled slug size is 12M
-    -----> Building Docker image
-    Uploading context 11.81 MB
-    Uploading context
-    Step 0 : FROM deis/slugrunner
-     ---> 5567a808891d
-    Step 1 : RUN mkdir -p /app
-     ---> Running in a4f8e66a79c1
-     ---> 5c07e1778b9e
-    Removing intermediate container a4f8e66a79c1
-    Step 2 : ADD slug.tgz /app
-     ---> 52d48b1692e5
-    Removing intermediate container e9dfce920e26
-    Step 3 : ENTRYPOINT ["/runner/init"]
-     ---> Running in 7a8416bce1f2
-     ---> 4a18f93f1779
-    Removing intermediate container 7a8416bce1f2
-    Successfully built 4a18f93f1779
-    -----> Pushing image to private registry
+    -----> Compiled slug size is 1.7M
+    Build complete.
+    Launching app.
+    Launching...
+    Done, skiing-keypunch:v2 deployed to Deis
 
-           Launching... done, v2
+    Use 'deis open' to view this application in your browser
 
-    -----> unisex-huntress deployed to Deis
-           http://unisex-huntress.local3.deisapp.com
+    To learn more, use 'deis help' or visit http://deis.io
 
-           To learn more, use `deis help` or visit http://deis.io
-
-    To ssh://git@local3.deisapp.com:2222/unisex-huntress.git
+    To ssh://git@deis.staging-2.deis.com:2222/skiing-keypunch.git
      * [new branch]      master -> master
 
-    $ curl -s http://unisex-huntress.local3.deisapp.com
-    Powered by Deis!
+    $ curl -s http://skiing-keypunch.example.com
+    Powered by Deis
+    Release v2 on skiing-keypunch-v2-web-02zb9
 
 Because a Heroku-style application is detected, the `web` process type is automatically scaled to 1 on first deploy.
 
 Use `deis scale web=3` to increase `web` processes to 3, for example. Scaling a
-process type directly changes the number of [Containers][container]
-running that process.
+process type directly changes the number of [pods] running that process.
 
 
 ## Included Buildpacks
@@ -150,7 +120,7 @@ and set `BUILDPACK_URL` to the URL:
     $ git push deis master
 
 
-[container]: ../reference-guide/terms.md#container
+[pods]: http://kubernetes.io/v1.1/docs/user-guide/pods.html
 [controller]: ../understanding-deis/components.md#controller
 [Ruby Buildpack]: https://github.com/heroku/heroku-buildpack-ruby
 [Nodejs Buildpack]: https://github.com/heroku/heroku-buildpack-nodejs


### PR DESCRIPTION
The output from the builder needed to be updated to accurately reflect what the v2 builder outputs.  Since this needed to be updated anyway, I also switched the doc to using the example-go app instead of example-ruby-sinatra since the former seems to be the app we have tested with most often... and is also not prone to whatever bug seems to currently be affecting deployment of the latter.