### PR TITLE
doc(install/contrib): Remove DO and bare metal instructions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,8 +12,6 @@ pages:
   - Installing Deis:
     - Quick Start: installing-deis/quickstart.md
     - System Requirements: installing-deis/system-requirements.md
-    - Bare Metal: installing-deis/bare-metal.md
-    - DigitalOcean: installing-deis/digitalocean.md
     - Installing the Deis Platform: installing-deis/installing-the-deis-platform.md
   - Using Deis:
     - Installing the Client: using-deis/installing-the-client.md

--- a/src/contributing/development-environment.md
+++ b/src/contributing/development-environment.md
@@ -135,32 +135,7 @@ Although writing and executing tests are critical to ensuring code quality, most
 
 ### Running a Kubernetes Cluster for Development
 
-Before proceding further, it is imperative to understand that all Deis components, including the Deis PaaS ([deis/workflow][workflow]) run atop the [Kubernetes][k8s] container orchestration system.  Whether for production or development and testing, a healthy Kubernetes cluster (version 1.1 or greater) is the required starting point.
-
-All Deis components treat Kubernetes as the lowest common denominator and Deis components make no assumptions about:
-
-* Your hosts' underlying operating system(s).
-* The underlying physical or virtual infrastructure.  It makes no difference whether your hosts:
-  * Are physical machines (i.e. bare metal).
-  * Are virtual machines provisioned through a cloud provider.
-  * Are virtual machines running locally on your laptop.
-
-With Kubernetes used as a uniform interface between Deis components and the infrastructure below, it is also (largely) unimportant to Deis components _how_ your Kubernetes cluster was provisioned.  As such, the Deis team is also not strongly opinionated (at this time) about how best to provision a Kubernetes cluster.
-
-Any official options listed on Kubernetes own [Getting Started][k8s-getting-started] page should be sufficient.
-
-#### DigitalOcean
-
-In many cases, testing your changes to Deis components is accomplished most easily and economically on just a few Vagrant VMs - sometimes just one.  However, at times, if one wishes to conserve local resources, test changes at scale, or demonstrate changes to others, it is advisable to move these activities into a cloud environment. 
-
-[DigitalOcean][] is Deis' officially recommended provider for contributors wishing to extend their development and testing into the cloud.  See [Provision a new DO cluster](../installing-deis/digitalocean.md) for further details and then continue to follow the instructions below.
-
-!!! important
-    Are you a new contributor to Deis? Your first [Pull Request][pr] could earn you credit at [DigitalOcean][]! Submit your changes and then email <deis@engineyard.com>. When your PR is merged, the maintainer team will send you a DigitalOcean credit based on the value of your contribution.
-
-### Installing Deis Components
-
-With a functioning Kubernetes cluster, proceed with Deis installation using [these instructions](../installing-deis/digitalocean.md) and then continue to follow the instructions below.
+To run a Kubernetes cluster locally or elsewhere to support your development activities, refer to Deis installation instructions [here](../installing-deis/quickstart.md).
 
 ### Using a Development Registry
 
@@ -186,7 +161,7 @@ In non-Linux environments:
 export DEIS_REGISTRY=<IP of the docker-deis Docker Machine VM>:5000/
 ```
 
-If your development cluster runs on a cloud provider such as DigitalOcean, a local registry such as the one above will not be accessible to your Kubernetes nodes.  In such cases, a public registry such as [DockerHub][dh] or [quay.io][quay] will suffice.
+If your development cluster runs on a cloud provider such as Google Container Engine, a local registry such as the one above will not be accessible to your Kubernetes nodes.  In such cases, a public registry such as [DockerHub][dh] or [quay.io][quay] will suffice.
 
 To use DockerHub for this purpose, for instance:
 
@@ -275,7 +250,6 @@ things you should do when proposing a change to any Deis component.
 [testing]: testing.md
 [k8s]: http://kubernetes.io/
 [k8s-getting-started]: http://kubernetes.io/gettingstarted/
-[digitalocean]: https://www.digitalocean.com/
 [pr]: submitting-a-pull-request.md
 [dh]: https://hub.docker.com/
 [quay]: https://quay.io/

--- a/src/contributing/overview.md
+++ b/src/contributing/overview.md
@@ -16,9 +16,6 @@ We are always looking for help improving the core platform, other workloads, too
 
 When you're ready to begin writing code, review [Design Documents][dd] and get your [Development Environment][dev-environment] set up.
 
-!!! important
-    If you're a new contributor to Deis, your Pull Request could earn you [credit at DigitalOcean][do-credit]!
-
 ## Triage Issues
 
 If you don't have time to code, consider helping with triage. The community will thank you for saving them time by spending some of yours. See [Triaging Issues](triaging-issues.md) for more info.
@@ -30,6 +27,5 @@ Interact with the community on our user mailing list or live in our IRC channel,
 [workflow]: https://github.com/deis/workflow
 [dd]: design-documents.md
 [dev-environment]: development-environment.md
-[do-credit]: development-environment.md#digitalocean-credit
 [docs]: https://github.com/deis/workflow/tree/master/docs
 [easy-fix]: https://github.com/deis/workflow/labels/easy-fix

--- a/src/installing-deis/bare-metal.md
+++ b/src/installing-deis/bare-metal.md
@@ -1,3 +1,0 @@
-# Bare Metal
-
-TODO: adopt <http://kubernetes.io/v1.1/docs/getting-started-guides/fedora/fedora_manual_config.html> here

--- a/src/installing-deis/digitalocean.md
+++ b/src/installing-deis/digitalocean.md
@@ -1,3 +1,0 @@
-# DigitalOcean
-
-TODO: update and adopt <https://github.com/bketelsen/coreos-kubernetes-digitalocean> here

--- a/src/installing-deis/quickstart.md
+++ b/src/installing-deis/quickstart.md
@@ -14,6 +14,8 @@ Choose one of the following providers and deploy a new kubernetes cluster:
 - [Google Container Engine](https://cloud.google.com/container-engine/docs/before-you-begin)
 - [Vagrant](http://kubernetes.io/v1.1/docs/getting-started-guides/vagrant.html)
 
+Reference [this table](http://kubernetes.io/v1.1/docs/getting-started-guides/#table-of-solutions) in the official Kubernetes documentation for a more extensive (but still non-exhaustive) list of Kubernetes provisioning options supported by the project or the community.
+
 ## Prerequisites
 Please make sure you enable the Daemon Sets api if you are installing a pre-1.2 version of kubernetes. As it is not turned on by default. You can learn more about how to do that [here](http://kubernetes.io/v1.1/docs/api.html#enabling-resources-in-the-extensions-group).
 


### PR DESCRIPTION
Completely inconsistent with how we called out our preferred zero-to-k8s options, we still had individual pages (albeit placeholders) for bare metal and DigitalOcean.  This PR removes those pages and amends our list of preferred zero-to-k8s options with a link to the k8s doc's own (non-exhaustive) table of project-supported and community-supported options.

At the same time, I also removed references to DigitalOcean as our prefered development environment because there is no officially supported k8s on DigitalOcean-- only a community-supported option-- _and_ we have not really tested v2 on that platform ourselves yet either.