### PR TITLE
fix(platform-ssl.md): update link to self-signed SSL doc

### DIFF
--- a/src/managing-deis/platform-ssl.md
+++ b/src/managing-deis/platform-ssl.md
@@ -6,7 +6,7 @@ private and integral.
 
 To enable SSL for your cluster and all apps running upon it, you can add an SSL key to your load
 balancer. You must either provide an SSL certificate that was registered with a CA or provide
-[your own self-signed SSL certificate](../reference-guide/creating_self_signed_ssl.md).
+[your own self-signed SSL certificate](../reference-guide/creating-a-self-signed-ssl-certificate.md).
 
 ## Installing SSL on a Load Balancer
 


### PR DESCRIPTION
The `mkdocs` build is currently broken due to an incorrect internal link:
```console
$ make build
...
DEBUG   -  Building page managing-deis/platform-ssl.md 
ERROR   -  Error building page managing-deis/platform-ssl.md 
Error: The page "managing-deis/platform-ssl.md" contained a hyperlink to "reference-guide/creating_self_signed_ssl.md" which is not listed in the "pages" configuration.
make: *** [build] Error 1
```