### PR TITLE
doc(welcome): Fix repetition of 'Workflow is a PaaS'

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,6 @@
 # Welcome to Deis Workflow
 
-Deis (pronounced DAY-iss) Workflow is an open source PaaS that makes it easy to deploy and manage applications on your own servers. Deis Workflow adds a developer-friendly Platform as a Service (PaaS) layer to any Kubernetes cluster, including: a simple REST API, application log aggregation, release and rollback, edge routing, git-push-to-container image, and authentication and authorization.
+Deis (pronounced DAY-iss) Workflow is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any Kubernetes cluster, making it easy to deploy and manage applications on your own servers.  It includes capabilities for building and deploying from source via git push, configuring your applications, managing and rolling back releases, managing application domain names and SSL certificates, edge routing, application log aggregation, and managing access to application resources.  All of this is exposed through a simple REST API and command line interface.
 
 To get started with Workflow, follow our [Quick Start][quickstart] guide.
 


### PR DESCRIPTION
The existing welcome page stutters by telling us twice in the first two sentences that Deis is a PaaS.  This PR corrects that by collapsing these two sentences and re-organizing those that immediately follow.