### PR TITLE
doc(architecture): Improve sentence flow

### DIFF
--- a/src/understanding-deis/architecture.md
+++ b/src/understanding-deis/architecture.md
@@ -28,7 +28,7 @@ Deis Workflow provides additional functionality to your Kubernetes cluster, incl
 
 ## Kubernetes-Native
 
-Every platform component and applications deployed via Workflow expect to be
+All platform components and applications deployed via Workflow expect to be
 running on an existing Kubernetes cluster. This means that you can happily run
 your Kubernetes-native workloads next to applications that are managed through
 Deis Workflow.


### PR DESCRIPTION
I may need to beg forgiveness for picking this nit.

There is nothing technically wrong with this sentence, but as soon as you've read "Every platform component and applications," it sounds very strange because the adjective "every" doesn't seem to agree with the plural "applications."  If you read on, the sentence eventually makes sense, but it was confusing enough to me that I had to read it twice.

Also, "every platform" doesn't sound like it agrees with the verb "expect."  Again, after a couple readings, the meaning becomes clear because it's the _collective_ of "every platform component and applications..." that are the subjects of the verb "expect."  But it's better when sentences don't require multiple readings to parse.

This simple fix makes it flow a bit better.