### PR TITLE
doc(installing): Don't always monospace helm

### DIFF
--- a/src/installing-deis/installing-deis-workflow.md
+++ b/src/installing-deis/installing-deis-workflow.md
@@ -1,7 +1,6 @@
 # Installing Deis Workflow
 
-We will use the `helm` utility to install Deis Workflow onto a Kubernetes cluster. If you don't
-have `helm` installed, see [installing helm][helm] for more info.
+We will use the Helm package manager for Kubernetes to install Deis Workflow onto a Kubernetes cluster. If you don't have Helm installed, see [Helm's own documentation][helm] for more info.
 
 ## Check Your Setup
 
@@ -13,7 +12,7 @@ $ helm --version
 ```
 
 Ensure your kubectl client is installed and ensure it can connect to your Kubernetes cluster. This
-is where `helm` will attempt to communicate with the cluster. You can test that it is working
+is where Helm will attempt to communicate with the cluster. You can test that it is working
 properly by running:
 
 ```


### PR DESCRIPTION
Another nit...

Reading through the docs, I felt assaulted by the continuous use of `monospacing` in reference to Helm.  It looks awkward in places where it's referring to the _product_ and not referring explicitly to either a _command_ that someone is meant to or to output _from_ some command.

By fixing this and also upcasing it to "Helm," Helm gets a little more respect as a product-- which it deserves.

I also changed the link that read "installing helm" to "Helm's own documentation," because I felt that was more appropriate, given that we're not linking to another section of the Workflow documentation, but rather to something external.