### PR TITLE
doc(obj-storage): Remove workflow/controller from list

### DIFF
--- a/src/installing-deis/configuring-object-storage.md
+++ b/src/installing-deis/configuring-object-storage.md
@@ -2,7 +2,6 @@
 
 A variety of Deis components rely on an object storage system to do their work. These components are:
 
-- [workflow](https://github.com/deis/workflow)
 - [builder](https://github.com/deis/builder)
 - [slugbuilder](https://github.com/deis/slugbuilder)
 - [slugrunner](https://github.com/deis/slugrunner)


### PR DESCRIPTION
I double-checked this with @helgi and it's not quite accurate that the workflow component (what will be called controller, I guess, going forward) is dependent upon object storage.  As such, this PR strikes it from the list of components that depend on object storage.