### PR TITLE
doc(process types): Eliminate repition and generally polish

### DIFF
--- a/src/using-deis/process-types-and-the-procfile.md
+++ b/src/using-deis/process-types-and-the-procfile.md
@@ -1,23 +1,25 @@
 # Process Types and the Procfile
 
-A Procfile is a mechanism for declaring what commands are run by your application’s containers on
-the Deis platform. It follows the [process model][]. You can use a Procfile to declare various
-process types, such as multiple types of workers, a singleton process like a clock, or a consumer
-of the Twitter streaming API.
+Deis Workflow observes the [process model][].  As part of this model, a Procfile may be used as a
+mechanism for declaring the commands that should be run by your application’s containers.  You can
+use a Procfile to declare multiple processes for different types of application workers-- for
+example, an application server, a job execution timer, or a consumer of the Twitter streaming API.
 
-## Process Types as Templates
+Multiple process types can be scaled independently of one another.
 
-A Procfile is a text file named `Procfile` placed in the root of your application that lists the
-process types in an application. Each process type is a declaration of a command that is executed
-when a container of that process type is started.
+## Default Process Types
 
-All the language and frameworks using [Heroku's Buildpacks](using-buildpacks.md) declare a
-`web` process type, which starts the application server. Rails 3 has the following process type:
+In the absence of a Procfile, a single, default process type is assumed for each application.
+
+All applications built using [Heroku's Buildpacks][buildpacks] implicitly declare a
+`web` process type, which starts the application server. Rails 4, for example, has the following
+process type:
 
     web: bundle exec rails server -p $PORT
 
-All applications using [Dockerfile deployments](using-dockerfiles.md) have an implied `cmd`
-process type, which spawns the default process of a Docker image:
+All applications utilizing [Dockerfile deployments][dockerfile] have an implied `cmd`
+process type, which spawns the default process of a Docker image as specified by the
+`Dockerfile`'s `CMD` directive:
 
     $ cat Dockerfile
     FROM centos:latest
@@ -26,69 +28,75 @@ process type, which spawns the default process of a Docker image:
     CMD python -m SimpleHTTPServer 5000
     EXPOSE 5000
 
-For applications using [Docker image deployments](using-docker-images.md), a `cmd` process
+For applications utilizing [Docker image deployments][docker image], a `cmd` process
 type is also implied and spawns the default process of the image.
 
 
 ## Declaring Process Types
 
-Process types are declared via a file named `Procfile`, placed in the root of your app. Its
-format is one process type per line, with each line containing:
+Developers utilizing [Heroku's Buildpacks][buildpacks] or [Dockerfile deployments][dockerfile] and
+wishing to override the implied, default process types, or declare additional process
+types may do so by including a file named `Procfile` in the root of their application's source
+tree.
+
+Developers utilizing [Docker image deployments][docker image] may accomplish this with a
+`Procfile` in their working directory or by referencing a `Procfile` using the `--procfile` option
+of the `deis pull` command.  For example:
+
+    $ deis pull deis/example-go:latest --procfile="cmd: /app/bin/boot"
+
+The format of a `Procfile` is one process type per line, with each line containing:
 
     <process type>: <command>
 
 The syntax is defined as:
 
-`<process type>` – an alphanumeric string, is a name for your command, such as web, worker, urgentworker, clock, etc.
+`<process type>` – an alphanumeric string, is a name for your command, such as web, worker,
+	urgentworker, clock, etc.
 
 `<command>` – a command line to launch the process, such as `rake jobs:work`.
 
 !!! note
-    The web and cmd process types are special as they’re the only process types that will receive
-    HTTP traffic from Deis’s routers. Other process types can be named arbitrarily.
+    The `web` and `cmd` process types are special as they’re the only process types that will
+    receive HTTP traffic from Workflow’s routers. Other process types can be named arbitrarily.
 
 
-## Deploying to Deis
+## Scaling Processes
 
-A `Procfile` is not necessary to deploy most languages supported by Deis. The platform
-automatically detects the language and supplies a default `web` process type to boot the server.
+Once an application has been deployed, its process types can be scaled independently of one
+another.  For example, consider the following `Procfile`:
 
-Creating an explicit Procfile is recommended for greater control and flexibility over your app.
+    web: bundle exec rails server -p $PORT
+    worker: bundle exec rake resque:work
 
-For Deis to use your Procfile, add the Procfile to the root of your application, then push to Deis:
+Given the `Procfile` above, the `web` process could be scaled out:
 
-    $ git add .
-    $ git commit -m "Procfile"
-    $ git push deis master
-    ...
-    -----> Procfile declares process types: web, worker
-    Compiled slug size is 10.4MB
+    $ deis scale web=5
 
-           Launching... done, v2
+And the `worker` process could be left alone, or scaled out independently, to whatever extent is
+required:
+ 
+    $ deis scale worker=3
 
-    -----> unisex-huntress deployed to Deis
-           http://unisex-huntress.example.com
-
-For Docker image deployments, a Procfile in the current directory or specified by
-`deis pull --procfile` will define the default process types for the application.
-
-Use `deis scale web=3` to increase `web` processes to 3, for example. Scaling a
-process type directly changes the number of [Containers][container]
-running that process.
+Scaling a process type directly changes the number of [Containers][container] running that process.
 
 
 ## Web vs Cmd Process Types
 
-When deploying to Deis using a Heroku Buildpack, Deis boots the `web` process type to boot the
-application server. When you deploy an application that has a Dockerfile or uses [Docker
-images](using-docker-images.md), Deis boots the `cmd` process type. Both act similarly in that they
-are exposed to the router as web applications. However, The `cmd` process type is special because
-it is equivalent to running the [container][] without any additional arguments. Every other
-process type is equivalent to running the relevant command that is provided in the Procfile.
+When deploying to Deis Workflow using a Heroku Buildpack, Workflow boots the `web` process type to
+boot the application server. When you deploy an application that has a Dockerfile or uses [Docker
+images](using-docker-images.md), Workflow boots the `cmd` process type. Both act similarly in that
+they are exposed to the router as web applications. However, the `cmd` process type is special
+because, if left undefined, it is equivalent to running the [container][] without any additional
+arguments.  (i.e. The process specified by the Dockerfile or Docker image's `CMD` directive will
+be used.)
 
-When migrating from Heroku Buildpacks to a Docker-based deployment, Deis will not convert `web`
-process types to `cmd`. To do this, you'll have to manually scale down the old process type and
-scale the new process type up.
+If migrating an application from Heroku Buildpacks to a Docker-based deployment, Workflow will not
+automatically convert the `web` process type to `cmd`. To do this, you'll have to manually scale
+down the old process type and scale the new process type up.
 
 [container]: ../reference-guide/terms.md#container
 [process model]: https://devcenter.heroku.com/articles/process-model
+[buildpacks]: using-buildpacks.md
+[dockerfile]: using-dockerfiles.md
+[docker image]: using-docker-images.md


### PR DESCRIPTION
There was a lot of repetition of information in the process type docs.  I think it told me _three_ times that the `Procfile` goes in the root of my application's source tree.  I've edited this page to be a bit more concise.