### PR TITLE
doc(configuring-dns): Tip about not forgetting trailing slash

### DIFF
--- a/src/managing-deis/configuring-dns.md
+++ b/src/managing-deis/configuring-dns.md
@@ -66,7 +66,7 @@ create and deploy more applications to the cluster.
 ## Testing
 
 To test that traffic reaches its intended destination, a request can be
-sent to the Deis controller like so:
+sent to the Deis controller like so (do not forget the trailing slash!):
 
 ```
 curl http://deis.example.com/v2/


### PR DESCRIPTION
Sometimes the little things (like a trailing slash) take longer to figure out than you want to admit. Hopefully this saves somebody else some troubles :)