### PR TITLE
doc(using dockerfiles): Apply minor cleanup

### DIFF
--- a/src/using-deis/using-docker-images.md
+++ b/src/using-deis/using-docker-images.md
@@ -23,9 +23,9 @@ it to [DockerHub][].
 
 In order to deploy Docker images, they must conform to the following requirements:
 
- * The Docker image must EXPOSE only one port
- * The port must be listening for a HTTP connection
- * A default CMD must be specified for running the container
+* The Dockerfile must use the `EXPOSE` directive to expose exactly one port.
+* That port must be listening for an HTTP connection.
+* The Dockerfile must use the `CMD` directive to define the default process that will run within the container.
 
 
 ## Create an Application

--- a/src/using-deis/using-dockerfiles.md
+++ b/src/using-deis/using-dockerfiles.md
@@ -16,9 +16,9 @@ If you do not have an existing application, you can clone an example application
 
 In order to deploy Dockerfile applications, they must conform to the following requirements:
 
-* The Dockerfile must EXPOSE only one port
-* The port must be listening for a HTTP connection
-* A default CMD must be specified for running the container
+* The Dockerfile must use the `EXPOSE` directive to expose exactly one port.
+* That port must be listening for an HTTP connection.
+* The Dockerfile must use the `CMD` directive to define the default process that will run within the container.
 
 
 ## Create an Application


### PR DESCRIPTION
Nits... This PR monospaces Dockerfile directives, which seems more proper, and just generally improves the precision of language with respect to these requirements.