### PR TITLE
core(docs): callout doc version explicitly

### DIFF
--- a/themes/deis/base.html
+++ b/themes/deis/base.html
@@ -59,6 +59,11 @@
             </div>
             <div class="span6 column_calc contents">
                 <div class="doc-content">
+                    <div class="version-warning important">
+                        <p class="version-warning-title">Version 2</p>
+                        <p>This documentation is for Deis Workflow (v2). For v1 documentation visit <a href="http://docs.deis.io/en/latest/">http://docs.deis.io/en/latest/</a>.</p>
+                    </div>
+
                     {{ content }}
                 </div>
             </div>

--- a/themes/deis/static/css/main.css
+++ b/themes/deis/static/css/main.css
@@ -514,6 +514,24 @@ pre, code pre {
     color: #000!important;
     background-color: #f5f5f5!important;
 }
+.doc-content .version-warning {
+    padding: 10px;
+    margin-top: 10px;
+    border: solid 4px #00aeff;
+}
+.doc-content .version-warning .version-warning-title {
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 26px;
+    text-indent: 50px;
+}
+.doc-content .important .version-warning-title {
+    background: url(../img/glyphs.png) no-repeat 0 -81px;
+}
+.doc-content .version-warning a, .doc-content .version-warning a em, .doc-content .version-warning em {
+    font-style: normal!imporant;
+    color: #00aeff!important;
+}
 .doc-content .admonition {
     padding: 10px;
     margin-bottom: 10px;


### PR DESCRIPTION
Build a callout so folks aren't confused between the different versions of
documentation.

![image](https://cloud.githubusercontent.com/assets/28873/13558154/2591e3b0-e3b2-11e5-8792-93d781ea495d.png)
