### PR TITLE
doc(configuring-dns): Rewrite DNS docs for brevity and correctness

### DIFF
--- a/src/managing-workflow/configuring-load-balancers.md
+++ b/src/managing-workflow/configuring-load-balancers.md
@@ -11,3 +11,5 @@ These ports need to be open on the load balancers:
 If you want to configure SSL termination on your load balancer, see [Platform SSL](platform-ssl.md).
 
 A health check should be configured on the load balancer to send an HTTP request to /healthz at port 9090 on all nodes in the Deis cluster. The health check endpoint returns an HTTP 200. This enables the load balancer to serve traffic to whichever hosts happen to be running the router component at any moment.
+
+See [the router component's own documentation](https://github.com/deis/router#front-facing-load-balancer) for further details.


### PR DESCRIPTION
This is a reorganization of existing information for better flow, with minor edits for accuracy and brevity.

I also include a link to the router's own docs from the load balancer page, since _this_ page references the load balancer page.  I simply wanted readers to have further opportunities to go deeper and deeper into the details if they so choose.