### PR TITLE
doc(mkdocs): Put LB docs before DNS in tree

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,8 @@ pages:
   - Managing Workflow:
     - Adding/Removing Hosts: managing-workflow/adding-or-removing-hosts.md
     - Backing up and Restoring Data: managing-workflow/backing-up-and-restoring-data.md
-    - Configuring DNS: managing-workflow/configuring-dns.md
     - Configuring Load Balancers: managing-workflow/configuring-load-balancers.md
+    - Configuring DNS: managing-workflow/configuring-dns.md
     - Managing Disk Usage: managing-workflow/managing-disk-usage.md
     - Operational Tasks: managing-workflow/operational-tasks.md
     - Platform Logging: managing-workflow/platform-logging.md


### PR DESCRIPTION
This PR just moves the page on configuring load balancers ahead of the page on configuring DNS in the doc tree.  I feel this is a more logical order in which to present these topics to someone who is new to managing Workflow.

Note the load balancer page needs some rework still, but I'll open a separate issue and PR for that.